### PR TITLE
Made Command that fetches the permanent invite url of Guild.

### DIFF
--- a/Cake.Core/Discord/Modules/CakeModule.cs
+++ b/Cake.Core/Discord/Modules/CakeModule.cs
@@ -4,6 +4,9 @@ using Cake.Core.Discord.Services;
 using Discord.Commands;
 using Discord.WebSocket;
 
+using System.Linq;
+using Discord.Rest;
+
 namespace Cake.Core.Discord.Modules
 {
     [Group("cake")]
@@ -17,6 +20,70 @@ namespace Cake.Core.Discord.Modules
         {
             _service = service;
             _service.SetBaseModule(this);
+        }
+
+        [Command("invite")]
+        [Summary("cake invite (isPermanentInvite?)")]
+        [Remarks("Fetches an invite URL to the current guild which this command is executed in.")]
+        public async Task GetGuildInvite(bool permanentInvite = true) {
+            if (!(Context.Guild is SocketGuild guild)) {
+                await ReplyAsync("Please use this command in a server only!");
+                return;
+            }
+
+            await SendInviteForUser();
+
+            #region Local_Function
+
+            async Task SendInviteForUser() {
+                RestInviteMetadata[] invites = await FetchInvitesByPermanentInvite();
+
+                if (invites.Length <= 0) {
+                    await ReplyAsync(GetErrorMessageToSend());
+                } else {
+                    var inviteToUse = invites.FirstOrDefault();
+                    await ReplyAsync(inviteToUse.Url);
+                }
+            }
+
+            string GetErrorMessageToSend() {
+                if (permanentInvite) {
+                    return $"There is no permanent invites in this server! {System.Environment.NewLine} Ask your owner to create one.";
+                } else {
+                    return $"There is no invites in this server! {System.Environment.NewLine} Ask your owner to create one.";
+                }
+            }
+
+            async Task<RestInviteMetadata[]> FetchInvitesByPermanentInvite() {
+                if (permanentInvite) {
+                    return await FetchPermanentInvitesFromGuild();
+                } else {
+                    return (await guild.GetInvitesAsync()).ToArray();
+                }
+            }
+
+            async Task<RestInviteMetadata[]> FetchPermanentInvitesFromGuild() {
+                var guildInvites = await guild.GetInvitesAsync();
+
+                return guildInvites.Where(InviteIsPermanent).ToArray();
+            }
+
+            bool InviteIsPermanent(RestInviteMetadata invite) {
+
+                bool doesNotAge = invite.MaxAge == null;
+                if (!doesNotAge) {
+                    doesNotAge = invite.MaxAge == 0;
+                }
+
+                bool doesNotHaveMaxUses = invite.MaxUses == null;
+                if (!doesNotHaveMaxUses) {
+                    doesNotHaveMaxUses = invite.MaxUses == 0;
+                }
+
+                return doesNotAge && doesNotHaveMaxUses && !invite.IsTemporary && !invite.IsRevoked;
+            }
+
+            #endregion
         }
 
         [Command("status")]

--- a/Cake.Core/Discord/Modules/CakeModule.cs
+++ b/Cake.Core/Discord/Modules/CakeModule.cs
@@ -25,8 +25,10 @@ namespace Cake.Core.Discord.Modules
         [Command("invite")]
         [Summary("cake invite (isPermanentInvite?)")]
         [Remarks("Fetches an invite URL to the current guild which this command is executed in.")]
-        public async Task GetGuildInvite(bool permanentInvite = true) {
-            if (!(Context.Guild is SocketGuild guild)) {
+        public async Task GetGuildInvite(bool permanentInvite = true) 
+        {
+            if (!(Context.Guild is SocketGuild guild)) 
+            {
                 await ReplyAsync("Please use this command in a server only!");
                 return;
             }
@@ -35,48 +37,64 @@ namespace Cake.Core.Discord.Modules
 
             #region Local_Function
 
-            async Task SendInviteForUser() {
+            async Task SendInviteForUser() 
+            {
                 RestInviteMetadata[] invites = await FetchInvitesByPermanentInvite();
 
-                if (invites.Length <= 0) {
+                if (invites.Length <= 0) 
+                {
                     await ReplyAsync(GetErrorMessageToSend());
-                } else {
+                } 
+                else 
+                {
                     var inviteToUse = invites.FirstOrDefault();
                     await ReplyAsync(inviteToUse.Url);
                 }
             }
 
-            string GetErrorMessageToSend() {
-                if (permanentInvite) {
-                    return $"There is no permanent invites in this server! {System.Environment.NewLine} Ask your owner to create one.";
-                } else {
-                    return $"There is no invites in this server! {System.Environment.NewLine} Ask your owner to create one.";
+            string GetErrorMessageToSend() 
+            {
+                if (permanentInvite) 
+                {
+                    return $"There is no permanent invites in this server! {System.Environment.NewLine}Ask your owner to create one.";
+                } 
+                else 
+                {
+                    return $"There is no invites in this server! {System.Environment.NewLine}Ask your owner to create one.";
                 }
             }
 
-            async Task<RestInviteMetadata[]> FetchInvitesByPermanentInvite() {
-                if (permanentInvite) {
+            async Task<RestInviteMetadata[]> FetchInvitesByPermanentInvite()
+            {
+                if (permanentInvite) 
+                {
                     return await FetchPermanentInvitesFromGuild();
-                } else {
+                } 
+                else 
+                {
                     return (await guild.GetInvitesAsync()).ToArray();
                 }
             }
 
-            async Task<RestInviteMetadata[]> FetchPermanentInvitesFromGuild() {
+            async Task<RestInviteMetadata[]> FetchPermanentInvitesFromGuild() 
+            {
                 var guildInvites = await guild.GetInvitesAsync();
 
                 return guildInvites.Where(InviteIsPermanent).ToArray();
             }
 
-            bool InviteIsPermanent(RestInviteMetadata invite) {
+            bool InviteIsPermanent(RestInviteMetadata invite) 
+            {
 
                 bool doesNotAge = invite.MaxAge == null;
-                if (!doesNotAge) {
+                if (!doesNotAge) 
+                {
                     doesNotAge = invite.MaxAge == 0;
                 }
 
                 bool doesNotHaveMaxUses = invite.MaxUses == null;
-                if (!doesNotHaveMaxUses) {
+                if (!doesNotHaveMaxUses) 
+                {
                     doesNotHaveMaxUses = invite.MaxUses == 0;
                 }
 


### PR DESCRIPTION
Based on Issue #42 

The user can do `>cake invite` to make the bot fetch a permanent invite url for the server.

Additionally, if the user only wanted to fetch *any* invite url, the user can do<br>`>cake invite false`<br>And it will fetch *any* invite url from the guild.

The command will warn the user if no suitable invite exists in the guild.
Additionally, the command will also warn the user if the command is invoked in a non-server.


