### PR TITLE
Added listing of all the commands.

### DIFF
--- a/Cake.Core/Discord/Handlers/CommandHandler.cs
+++ b/Cake.Core/Discord/Handlers/CommandHandler.cs
@@ -120,8 +120,7 @@ namespace Cake.Core.Discord.Handlers
                     }
                     else
                     {
-                        // TODO: UNCOMMENT
-                        //await LevelHandler.GiveExpToUser(user, 2);
+                        await LevelHandler.GiveExpToUser(user, 2);
                         _logger.Log(Type.Info, $"\nCommand {context.Message} executed by {context.User}({context.User.Id}) in guild {context.Guild}({context.Guild.Id})\nTime taken to execute command is {stopwatch.ElapsedMilliseconds}ms");
                     }
                 }

--- a/Cake.Core/Discord/Handlers/CommandHandler.cs
+++ b/Cake.Core/Discord/Handlers/CommandHandler.cs
@@ -30,6 +30,10 @@ namespace Cake.Core.Discord.Handlers
             _client.UserJoined += JoinHandler.UserJoined;
             _client.UserLeft += JoinHandler.UserLeft;
 
+            _client.ReactionAdded += MessageReactionHandler.OnReactionAdded;
+            _client.ReactionRemoved += MessageReactionHandler.OnReactionRemoved;
+            _client.ReactionsCleared += MessageReactionHandler.OnReactionCleared;
+
             await _commandService.AddModulesAsync(Assembly.GetExecutingAssembly(), _services);
         }
 
@@ -52,16 +56,18 @@ namespace Cake.Core.Discord.Handlers
 
             try
             {
+                // TODO: UNCOMMENT THESE:
                 //Get or generation of user.
-                var user = await Database.Queries.UserQueries.FindOrCreateUser(context.User.Id);
-                var guild = await Database.Queries.GuildQueries.FindOrCreateGuild(context.Guild.Id);
+                //var user = await Database.Queries.UserQueries.FindOrCreateUser(context.User.Id);
+                //var guild = await Database.Queries.GuildQueries.FindOrCreateGuild(context.Guild.Id);
 
-                if (context.Message.HasCharPrefix(Convert.ToChar(guild.Prefix), ref argPos))
+                if (context.Message.HasCharPrefix(Convert.ToChar(">"/*guild.Prefix*/), ref argPos))
                 {
-                    if (user.Restrict && guild.Restrict)
-                    {
-                        return;
-                    }
+                    // TODO: UNCOMMENT
+                    //if (user.Restrict && guild.Restrict)
+                    //{
+                    //    return;
+                    //}
 
                     var stopwatch = Stopwatch.StartNew();
                     //Execute Command
@@ -116,7 +122,8 @@ namespace Cake.Core.Discord.Handlers
                     }
                     else
                     {
-                        await LevelHandler.GiveExpToUser(user, 2);
+                        // TODO: UNCOMMENT
+                        //await LevelHandler.GiveExpToUser(user, 2);
                         _logger.Log(Type.Info, $"\nCommand {context.Message} executed by {context.User}({context.User.Id}) in guild {context.Guild}({context.Guild.Id})\nTime taken to execute command is {stopwatch.ElapsedMilliseconds}ms");
                     }
                 }

--- a/Cake.Core/Discord/Handlers/CommandHandler.cs
+++ b/Cake.Core/Discord/Handlers/CommandHandler.cs
@@ -56,18 +56,16 @@ namespace Cake.Core.Discord.Handlers
 
             try
             {
-                // TODO: UNCOMMENT THESE:
                 //Get or generation of user.
-                //var user = await Database.Queries.UserQueries.FindOrCreateUser(context.User.Id);
-                //var guild = await Database.Queries.GuildQueries.FindOrCreateGuild(context.Guild.Id);
+                var user = await Database.Queries.UserQueries.FindOrCreateUser(context.User.Id);
+                var guild = await Database.Queries.GuildQueries.FindOrCreateGuild(context.Guild.Id);
 
-                if (context.Message.HasCharPrefix(Convert.ToChar(">"/*guild.Prefix*/), ref argPos))
+                if (context.Message.HasCharPrefix(Convert.ToChar(guild.Prefix), ref argPos))
                 {
-                    // TODO: UNCOMMENT
-                    //if (user.Restrict && guild.Restrict)
-                    //{
-                    //    return;
-                    //}
+                    if (user.Restrict && guild.Restrict)
+                    {
+                        return;
+                    }
 
                     var stopwatch = Stopwatch.StartNew();
                     //Execute Command
@@ -94,9 +92,9 @@ namespace Cake.Core.Discord.Handlers
                                 await context.Channel.SendMessageAsync($"``{context.User} lack the sufficient permissions, check usage of command.``");
                                 break;
                             case CommandError.Exception:
-                                if(result.ErrorReason.Contains("Missing Permissions"))
+                                if (result.ErrorReason.Contains("Missing Permissions"))
                                 {
-                                    _logger.Log(Type.Info,$"\nNo permissions in guild {context.Guild}{context.Guild.Id}\nTrying to PM {context.User}.");
+                                    _logger.Log(Type.Info, $"\nNo permissions in guild {context.Guild}{context.Guild.Id}\nTrying to PM {context.User}.");
                                     try
                                     {
                                         var dmChannel = await context.User.GetOrCreateDMChannelAsync();

--- a/Cake.Core/Discord/Handlers/MessageReactionHandler/IMessageReactionHandle.cs
+++ b/Cake.Core/Discord/Handlers/MessageReactionHandler/IMessageReactionHandle.cs
@@ -1,0 +1,27 @@
+﻿using Discord;
+using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cake.Core.Discord.Handlers
+{
+    public interface IMessageReactionHandle
+    {
+        /// <summary>
+        /// Invoked when a reaction has been added to the message.
+        /// </summary>
+        Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3);
+
+        /// <summary>
+        /// Invoked when a reaction has been removed to the message.
+        /// </summary>
+        Task OnReactionRemoved(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3);
+
+        /// <summary>
+        /// Invoked when all the reactions has been cleared from the message.
+        /// </summary>
+        Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2);
+    }
+}

--- a/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
+++ b/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
@@ -1,0 +1,70 @@
+﻿using Discord.WebSocket;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Discord;
+using System.Threading.Tasks;
+
+namespace Cake.Core.Discord.Handlers
+{
+    public static class MessageReactionHandler
+    {
+
+        private static HashSet<IMessageReactionHandle> messageReactionHandlers;
+
+        static MessageReactionHandler()
+        {
+            messageReactionHandlers = new HashSet<IMessageReactionHandle>();
+        }
+
+        internal static Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
+        {
+            foreach (var handle in messageReactionHandlers)
+            {
+                handle.OnReactionAdded(arg1, arg2, arg3);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        internal static Task OnReactionRemoved(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3) {
+
+            foreach (var handle in messageReactionHandlers)
+            {
+                handle.OnReactionRemoved(arg1, arg2, arg3);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        internal static Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2) {
+
+            foreach (var handle in messageReactionHandlers)
+            {
+                handle.OnReactionCleared(arg1, arg2);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        #region Util
+
+        public static void AddMessageReactionHandle(IMessageReactionHandle messageReactionHandle)
+        {
+            if (messageReactionHandle == null)
+            {
+                throw new ArgumentNullException(nameof(messageReactionHandle));
+            }
+
+            messageReactionHandlers.Add(messageReactionHandle);
+        }
+
+        public static void RemoveMessageReactionHandle(IMessageReactionHandle messageReactionHandle)
+        {
+            messageReactionHandlers.Remove(messageReactionHandle);
+        }
+
+        #endregion
+    }
+}

--- a/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
+++ b/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
@@ -11,16 +11,16 @@ namespace Cake.Core.Discord.Handlers
     public static class MessageReactionHandler
     {
 
-        private static HashSet<IMessageReactionHandle> messageReactionHandlers;
+        private static HashSet<IMessageReactionHandle> _messageReactionHandlers;
 
         static MessageReactionHandler()
         {
-            messageReactionHandlers = new HashSet<IMessageReactionHandle>();
+            _messageReactionHandlers = new HashSet<IMessageReactionHandle>();
         }
 
         internal static Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
         {
-            foreach (var handle in messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers)
             {
                 handle.OnReactionAdded(arg1, arg2, arg3);
             }
@@ -30,7 +30,7 @@ namespace Cake.Core.Discord.Handlers
 
         internal static Task OnReactionRemoved(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3) {
 
-            foreach (var handle in messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers)
             {
                 handle.OnReactionRemoved(arg1, arg2, arg3);
             }
@@ -40,7 +40,7 @@ namespace Cake.Core.Discord.Handlers
 
         internal static Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2) {
 
-            foreach (var handle in messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers)
             {
                 handle.OnReactionCleared(arg1, arg2);
             }
@@ -57,12 +57,12 @@ namespace Cake.Core.Discord.Handlers
                 throw new ArgumentNullException(nameof(messageReactionHandle));
             }
 
-            messageReactionHandlers.Add(messageReactionHandle);
+            _messageReactionHandlers.Add(messageReactionHandle);
         }
 
         public static void RemoveMessageReactionHandle(IMessageReactionHandle messageReactionHandle)
         {
-            messageReactionHandlers.Remove(messageReactionHandle);
+            _messageReactionHandlers.Remove(messageReactionHandle);
         }
 
         #endregion

--- a/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
+++ b/Cake.Core/Discord/Handlers/MessageReactionHandler/MessageReactionHandler.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using System.Linq;
+
 using Discord;
 using System.Threading.Tasks;
 
@@ -20,7 +22,7 @@ namespace Cake.Core.Discord.Handlers
 
         internal static Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
         {
-            foreach (var handle in _messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers.ToArray())
             {
                 handle.OnReactionAdded(arg1, arg2, arg3);
             }
@@ -30,7 +32,7 @@ namespace Cake.Core.Discord.Handlers
 
         internal static Task OnReactionRemoved(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3) {
 
-            foreach (var handle in _messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers.ToArray())
             {
                 handle.OnReactionRemoved(arg1, arg2, arg3);
             }
@@ -40,7 +42,7 @@ namespace Cake.Core.Discord.Handlers
 
         internal static Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2) {
 
-            foreach (var handle in _messageReactionHandlers)
+            foreach (var handle in _messageReactionHandlers.ToArray())
             {
                 handle.OnReactionCleared(arg1, arg2);
             }

--- a/Cake.Core/Discord/Modules/CakeModule.cs
+++ b/Cake.Core/Discord/Modules/CakeModule.cs
@@ -181,6 +181,7 @@ namespace Cake.Core.Discord.Modules
         [Command("setadmin")]
         [Alias("sa")]
         [RequireBotAdmin]
+        [Hide]
         public async Task SetAdminMention(SocketGuildUser user)
         {
             await _service.SetAdmin(user.Id);

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -75,8 +75,7 @@ namespace Cake.Core.Discord.Modules
 
         private void OnInactivityTimerElapsed(object sender, ElapsedEventArgs e)
         {
-            MessageReactionHandler.RemoveMessageReactionHandle(this);
-            DisposeTimer();
+            DisposeThisHelpBook();
         }
 
         public Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
@@ -99,8 +98,7 @@ namespace Cake.Core.Discord.Modules
                 else
                 {
                     // This message was probably deleted before we can do anything else.
-                    MessageReactionHandler.RemoveMessageReactionHandle(this);
-                    DisposeTimer();
+                    DisposeThisHelpBook();
                 }
             }
 
@@ -159,8 +157,7 @@ namespace Cake.Core.Discord.Modules
             }
             else
             {
-                MessageReactionHandler.RemoveMessageReactionHandle(this);
-                DisposeTimer();
+                DisposeThisHelpBook();
             }
 
             return Task.CompletedTask;
@@ -172,6 +169,11 @@ namespace Cake.Core.Discord.Modules
         }
 
         #region Util
+
+        private void DisposeThisHelpBook() {
+            MessageReactionHandler.RemoveMessageReactionHandle(this);
+            DisposeTimer();
+        }
 
         private void ResetTimer() {
             _inactivityTimer.Stop();

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Timers;
 using Cake.Core.Discord.Embed.Builder;
 using Cake.Core.Discord.Handlers;
-using Cake.Core.Logging;
 using Discord;
 using Discord.WebSocket;
 
@@ -204,7 +201,7 @@ namespace Cake.Core.Discord.Modules
             {
                 _currentPageIndex = 0;
             }
-            else if (_currentPageIndex <= 0)
+            else if (_currentPageIndex < 0)
             {
                 _currentPageIndex = _helpPages.Count - 1;
             }

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -126,12 +126,12 @@ namespace Cake.Core.Discord.Modules
 
                 if (arg3.Emote.Name.Equals(RightArrowEmojiDisplayName))
                 {
-                    FlipNextHelpPage();
+                    FlipPreviousHelpPage();
                     pageFlipped = true;
                 }
                 else if (arg3.Emote.Name.Equals(LeftArrowEmojiDisplayName))
                 {
-                    FlipPreviousHelpPage();
+                    FlipNextHelpPage();
                     pageFlipped = true;
                 }
 

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -11,11 +11,10 @@ namespace Cake.Core.Discord.Modules
 {
     internal class HelpBook : IMessageReactionHandle
     {
-        internal const string RightArrowEmojiDisplayName = "➡️";
-        internal const string LeftArrowEmojiDisplayName = "⬅️";
-
-        internal static readonly Emoji RightArrowEmoji = new Emoji(RightArrowEmojiDisplayName);
-        internal static readonly Emoji LeftArrowEmoji = new Emoji(LeftArrowEmojiDisplayName);
+        internal static readonly string RightArrowEmojiDisplayName;
+        internal static readonly string LeftArrowEmojiDisplayName;
+        internal static readonly Emoji RightArrowEmoji;
+        internal static readonly Emoji LeftArrowEmoji;
 
         /// <summary>
         /// The ID of the message this help book is targeted towards.
@@ -26,13 +25,25 @@ namespace Cake.Core.Discord.Modules
 
         private int _currentPageIndex;
 
-        private CakeEmbedBuilder CurrentPage {
-            get {
+        private CakeEmbedBuilder CurrentPage
+        {
+            get
+            {
                 return _helpPages[_currentPageIndex];
             }
         }
 
-        internal HelpBook(List<CakeEmbedBuilder> helpPages, ulong targetMessageID) {
+        static HelpBook()
+        {
+            RightArrowEmojiDisplayName = ((char)11013).ToString();
+            LeftArrowEmojiDisplayName = ((char)10145).ToString();
+
+            RightArrowEmoji = new Emoji(RightArrowEmojiDisplayName);
+            LeftArrowEmoji = new Emoji(LeftArrowEmojiDisplayName);
+        }
+
+        internal HelpBook(List<CakeEmbedBuilder> helpPages, ulong targetMessageID)
+        {
             _helpPages = helpPages;
             _targetMessageID = targetMessageID;
             _currentPageIndex = 0;
@@ -40,17 +51,22 @@ namespace Cake.Core.Discord.Modules
 
         public Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
         {
-            if (ReactionAdderIsBot()) {
+            if (ReactionAdderIsBot())
+            {
                 return Task.CompletedTask;
             }
 
-            if (TryFlipPageByEmojiReaction()) {
-                if (TryGetUserMessageFromCachedMessage(arg1, out IUserMessage userMessage))
+            if (TryFlipPageByEmojiReaction())
+            {
+                IUserMessage userMessage = arg2.GetMessageAsync(arg1.Id).Result as IUserMessage;
+
+                if (userMessage != null)
                 {
-                    userMessage.RemoveReactionAsync(arg3.Emote, userMessage.Author);
+                    userMessage.RemoveReactionAsync(arg3.Emote, arg3.User.Value);
                     ShowNewPageOnMessage(ref userMessage);
                 }
-                else {
+                else
+                {
                     // This message was probably deleted before we can do anything else.
                     MessageReactionHandler.RemoveMessageReactionHandle(this);
                 }
@@ -60,21 +76,25 @@ namespace Cake.Core.Discord.Modules
 
             #region Local_Function
 
-            Task ShowNewPageOnMessage(ref IUserMessage message) {
+            Task ShowNewPageOnMessage(ref IUserMessage message)
+            {
                 message.ModifyAsync(msg => msg.Embed = CurrentPage.Build());
 
                 return Task.CompletedTask;
             }
-            bool ReactionAdderIsBot() {
+            bool ReactionAdderIsBot()
+            {
                 var reactionAdder = arg3.User;
-                if (reactionAdder.IsSpecified) {
+                if (reactionAdder.IsSpecified)
+                {
                     return reactionAdder.Value.IsBot;
                 }
 
                 return false;
             }
 
-            bool TryFlipPageByEmojiReaction() {
+            bool TryFlipPageByEmojiReaction()
+            {
                 bool pageFlipped = false;
 
                 if (arg3.Emote.Name.Equals(RightArrowEmojiDisplayName))
@@ -82,7 +102,8 @@ namespace Cake.Core.Discord.Modules
                     FlipNextHelpPage();
                     pageFlipped = true;
                 }
-                else if (arg3.Emote.Name.Equals(LeftArrowEmojiDisplayName)) {
+                else if (arg3.Emote.Name.Equals(LeftArrowEmojiDisplayName))
+                {
                     FlipPreviousHelpPage();
                     pageFlipped = true;
                 }
@@ -95,12 +116,15 @@ namespace Cake.Core.Discord.Modules
 
         public Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2)
         {
-            if (TryGetUserMessageFromCachedMessage(arg1, out IUserMessage userMessage))
+            IUserMessage userMessage = arg2.GetMessageAsync(arg1.Id).Result as IUserMessage;
+
+            if (userMessage != null)
             {
                 // Add back the bot's reaction
-                userMessage.AddReactionsAsync(new IEmote[]{ LeftArrowEmoji, RightArrowEmoji });
+                userMessage.AddReactionsAsync(new IEmote[] { LeftArrowEmoji, RightArrowEmoji });
             }
-            else {
+            else
+            {
                 MessageReactionHandler.RemoveMessageReactionHandle(this);
             }
 
@@ -114,38 +138,26 @@ namespace Cake.Core.Discord.Modules
 
         #region Util
 
-        private bool TryGetUserMessageFromCachedMessage(Cacheable<IUserMessage, ulong> cachedMessage, out IUserMessage userMessage)
+        private void FlipNextHelpPage()
         {
-            bool canGetMessage = cachedMessage.HasValue;
-
-            if (canGetMessage)
-            {
-                userMessage = cachedMessage.Value;
-            }
-            else
-            {
-                userMessage = null;
-            }
-
-            return canGetMessage;
-        }
-
-        private void FlipNextHelpPage() {
             ++_currentPageIndex;
             ClampCurrentPageIndex();
         }
 
-        private void FlipPreviousHelpPage() {
+        private void FlipPreviousHelpPage()
+        {
             --_currentPageIndex;
             ClampCurrentPageIndex();
         }
 
-        private void ClampCurrentPageIndex() {
+        private void ClampCurrentPageIndex()
+        {
             if (_currentPageIndex >= _helpPages.Count)
             {
                 _currentPageIndex = 0;
             }
-            else if (_currentPageIndex <= 0) {
+            else if (_currentPageIndex <= 0)
+            {
                 _currentPageIndex = _helpPages.Count - 1;
             }
         }

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -81,7 +81,7 @@ namespace Cake.Core.Discord.Modules
 
         public Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
         {
-            if (ReactionAdderIsBot())
+            if (ReactionAdderIsBot() || arg1.Id != _targetMessageID)
             {
                 return Task.CompletedTask;
             }
@@ -148,6 +148,8 @@ namespace Cake.Core.Discord.Modules
 
         public Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2)
         {
+            if (arg1.Id != _targetMessageID) { return Task.CompletedTask; }
+
             IUserMessage userMessage = arg2.GetMessageAsync(arg1.Id).Result as IUserMessage;
 
             if (userMessage != null)

--- a/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpBook.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core.Discord.Embed.Builder;
+using Cake.Core.Discord.Handlers;
+using Discord;
+using Discord.WebSocket;
+
+namespace Cake.Core.Discord.Modules
+{
+    internal class HelpBook : IMessageReactionHandle
+    {
+        internal const string RightArrowEmojiDisplayName = "➡️";
+        internal const string LeftArrowEmojiDisplayName = "⬅️";
+
+        internal static readonly Emoji RightArrowEmoji = new Emoji(RightArrowEmojiDisplayName);
+        internal static readonly Emoji LeftArrowEmoji = new Emoji(LeftArrowEmojiDisplayName);
+
+        /// <summary>
+        /// The ID of the message this help book is targeted towards.
+        /// </summary>
+        private ulong _targetMessageID;
+
+        private List<CakeEmbedBuilder> _helpPages;
+
+        private int _currentPageIndex;
+
+        private CakeEmbedBuilder CurrentPage {
+            get {
+                return _helpPages[_currentPageIndex];
+            }
+        }
+
+        internal HelpBook(List<CakeEmbedBuilder> helpPages, ulong targetMessageID) {
+            _helpPages = helpPages;
+            _targetMessageID = targetMessageID;
+            _currentPageIndex = 0;
+        }
+
+        public Task OnReactionAdded(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
+        {
+            if (ReactionAdderIsBot()) {
+                return Task.CompletedTask;
+            }
+
+            if (TryFlipPageByEmojiReaction()) {
+                if (TryGetUserMessageFromCachedMessage(arg1, out IUserMessage userMessage))
+                {
+                    userMessage.RemoveReactionAsync(arg3.Emote, userMessage.Author);
+                    ShowNewPageOnMessage(ref userMessage);
+                }
+                else {
+                    // This message was probably deleted before we can do anything else.
+                    MessageReactionHandler.RemoveMessageReactionHandle(this);
+                }
+            }
+
+            return Task.CompletedTask;
+
+            #region Local_Function
+
+            Task ShowNewPageOnMessage(ref IUserMessage message) {
+                message.ModifyAsync(msg => msg.Embed = CurrentPage.Build());
+
+                return Task.CompletedTask;
+            }
+            bool ReactionAdderIsBot() {
+                var reactionAdder = arg3.User;
+                if (reactionAdder.IsSpecified) {
+                    return reactionAdder.Value.IsBot;
+                }
+
+                return false;
+            }
+
+            bool TryFlipPageByEmojiReaction() {
+                bool pageFlipped = false;
+
+                if (arg3.Emote.Name.Equals(RightArrowEmojiDisplayName))
+                {
+                    FlipNextHelpPage();
+                    pageFlipped = true;
+                }
+                else if (arg3.Emote.Name.Equals(LeftArrowEmojiDisplayName)) {
+                    FlipPreviousHelpPage();
+                    pageFlipped = true;
+                }
+
+                return pageFlipped;
+            }
+
+            #endregion
+        }
+
+        public Task OnReactionCleared(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2)
+        {
+            if (TryGetUserMessageFromCachedMessage(arg1, out IUserMessage userMessage))
+            {
+                // Add back the bot's reaction
+                userMessage.AddReactionsAsync(new IEmote[]{ LeftArrowEmoji, RightArrowEmoji });
+            }
+            else {
+                MessageReactionHandler.RemoveMessageReactionHandle(this);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task OnReactionRemoved(Cacheable<IUserMessage, ulong> arg1, ISocketMessageChannel arg2, SocketReaction arg3)
+        {
+            return Task.CompletedTask;
+        }
+
+        #region Util
+
+        private bool TryGetUserMessageFromCachedMessage(Cacheable<IUserMessage, ulong> cachedMessage, out IUserMessage userMessage)
+        {
+            bool canGetMessage = cachedMessage.HasValue;
+
+            if (canGetMessage)
+            {
+                userMessage = cachedMessage.Value;
+            }
+            else
+            {
+                userMessage = null;
+            }
+
+            return canGetMessage;
+        }
+
+        private void FlipNextHelpPage() {
+            ++_currentPageIndex;
+            ClampCurrentPageIndex();
+        }
+
+        private void FlipPreviousHelpPage() {
+            --_currentPageIndex;
+            ClampCurrentPageIndex();
+        }
+
+        private void ClampCurrentPageIndex() {
+            if (_currentPageIndex >= _helpPages.Count)
+            {
+                _currentPageIndex = 0;
+            }
+            else if (_currentPageIndex <= 0) {
+                _currentPageIndex = _helpPages.Count - 1;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
@@ -10,7 +10,7 @@ using Discord.Commands;
 namespace Cake.Core.Discord.Modules
 {
     [Hide]
-    
+
     public class HelpModule : CustomBaseModule
     {
         private readonly CommandService _commandService;
@@ -25,22 +25,32 @@ namespace Cake.Core.Discord.Modules
 
         [Hide]
         [Command("help")]
+        [Summary("help (searchFilter?)")]
         [Alias("cmds", "commands")]
         public async Task CommandHelp([Remainder] string command = "")
         {
             IUserMessage newMessage = await Context.Channel.SendMessageAsync("Fetching Commands...");
 
-            List<CakeEmbedBuilder> helpPages = await _service.FetchAllCommandInfoAsPages(_commandService);
+            List<CakeEmbedBuilder> helpPages = await _service.FetchAllCommandInfoAsPages(_commandService, command);
 
-            await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
+            if (helpPages.Count <= 0)
+            {
+                await newMessage.ModifyAsync(msg => msg.Content = "There is no matching command based on the search filter!");
+            }
+            else if (helpPages.Count == 1)
+            {
+                await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
+            }
+            else
+            {
+                await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
 
-            await newMessage.AddReactionsAsync(new Emoji[] { HelpBook.RightArrowEmoji, HelpBook.LeftArrowEmoji });
+                await newMessage.AddReactionsAsync(new Emoji[] { HelpBook.RightArrowEmoji, HelpBook.LeftArrowEmoji });
 
-            HelpBook helpBook = new HelpBook(helpPages, newMessage.Id);
+                HelpBook helpBook = new HelpBook(helpPages, newMessage.Id);
 
-            MessageReactionHandler.AddMessageReactionHandle(helpBook);
-
-            // TODO: Command searching filter
+                MessageReactionHandler.AddMessageReactionHandle(helpBook);
+            }
         }
     }
 }

--- a/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
@@ -36,15 +36,12 @@ namespace Cake.Core.Discord.Modules
             if (helpPages.Count <= 0)
             {
                 await newMessage.ModifyAsync(msg => msg.Content = "There is no matching command based on the search filter!");
+                return;
             }
-            else if (helpPages.Count == 1)
+            await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
+            
+            if (helpPages.Count != 1)
             {
-                await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
-            }
-            else
-            {
-                await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
-
                 await newMessage.AddReactionsAsync(new Emoji[] { HelpBook.RightArrowEmoji, HelpBook.LeftArrowEmoji });
 
                 HelpBook helpBook = new HelpBook(helpPages, newMessage.Id);

--- a/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
@@ -1,11 +1,14 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Cake.Core.Discord.Attributes;
+using Cake.Core.Discord.Embed.Builder;
 using Cake.Core.Discord.Services;
 using Discord.Commands;
 
 namespace Cake.Core.Discord.Modules
 {
     [Hide]
+    
     public class HelpModule : CustomBaseModule
     {
         private readonly CommandService _commandService;
@@ -23,14 +26,11 @@ namespace Cake.Core.Discord.Modules
         [Alias("cmds", "commands")]
         public async Task CommandHelp([Remainder] string command = "")
         {
-            if (command == "")
-            {
-                await _service.HelpAll(_commandService);
-            }
-            else
-            {
-                await _service.HelpCommand(_commandService, command);
-            }
+            List<CakeEmbedBuilder> helpPages = await _service.FetchAllCommandInfoAsPages(_commandService);
+
+
+
+            // TODO: Command searching filter
         }
     }
 }

--- a/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Cake.Core.Discord.Attributes;
 using Cake.Core.Discord.Embed.Builder;
+using Cake.Core.Discord.Handlers;
 using Cake.Core.Discord.Services;
 using Discord.Commands;
 
@@ -28,7 +29,9 @@ namespace Cake.Core.Discord.Modules
         {
             List<CakeEmbedBuilder> helpPages = await _service.FetchAllCommandInfoAsPages(_commandService);
 
+            HelpBook helpBook = new HelpBook(helpPages, Context.Message.Id);
 
+            MessageReactionHandler.AddMessageReactionHandle(helpBook);
 
             // TODO: Command searching filter
         }

--- a/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
+++ b/Cake.Core/Discord/Modules/HelpModule/HelpModule.cs
@@ -4,6 +4,7 @@ using Cake.Core.Discord.Attributes;
 using Cake.Core.Discord.Embed.Builder;
 using Cake.Core.Discord.Handlers;
 using Cake.Core.Discord.Services;
+using Discord;
 using Discord.Commands;
 
 namespace Cake.Core.Discord.Modules
@@ -27,9 +28,15 @@ namespace Cake.Core.Discord.Modules
         [Alias("cmds", "commands")]
         public async Task CommandHelp([Remainder] string command = "")
         {
+            IUserMessage newMessage = await Context.Channel.SendMessageAsync("Fetching Commands...");
+
             List<CakeEmbedBuilder> helpPages = await _service.FetchAllCommandInfoAsPages(_commandService);
 
-            HelpBook helpBook = new HelpBook(helpPages, Context.Message.Id);
+            await newMessage.ModifyAsync(msg => { msg.Embed = helpPages[0].Build(); msg.Content = string.Empty; });
+
+            await newMessage.AddReactionsAsync(new Emoji[] { HelpBook.RightArrowEmoji, HelpBook.LeftArrowEmoji });
+
+            HelpBook helpBook = new HelpBook(helpPages, newMessage.Id);
 
             MessageReactionHandler.AddMessageReactionHandle(helpBook);
 

--- a/Cake.Core/Discord/Services/HelpService.cs
+++ b/Cake.Core/Discord/Services/HelpService.cs
@@ -12,24 +12,30 @@ namespace Cake.Core.Discord.Services
 {
     public class HelpService : CustomBaseService
     {
-        public async Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service)
+        public Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service)
         {
             List<CakeEmbedBuilder> helpPage = new List<CakeEmbedBuilder>();
 
             foreach (ModuleInfo module in service.Modules)
             {
+                if (ModuleHasHideAttribute(module)) { continue; }
+
                 CakeEmbedBuilder newEmbedPage = new CakeEmbedBuilder();
 
                 PopulateEmbedWithModuleInfo(module, ref newEmbedPage);
                 PopulateEmbedFieldsWithModuleCommands(module, ref newEmbedPage);
+
+                helpPage.Add(newEmbedPage);
             }
 
-            return helpPage;
+            return Task.FromResult(helpPage);
         }
 
         private void PopulateEmbedFieldsWithModuleCommands(ModuleInfo moduleInfo, ref CakeEmbedBuilder cakeEmbedBuilder) {
 
             foreach (CommandInfo command in moduleInfo.Commands) {
+                if (CommandHasHideAttribute(command)) { continue; }
+
                 EmbedFieldBuilder commandField = GetEmbedFieldWithCommandInfo(command);
                 cakeEmbedBuilder.AddField(commandField);
             }
@@ -101,130 +107,138 @@ namespace Cake.Core.Discord.Services
             #endregion
         }
 
-
-        public async Task HelpAll(CommandService service)
-        {
-            var builder = new CakeEmbedBuilder(EmbedType.Info)
-            {
-                Title = "My commands: "
-            };
-
-            var isAdmin = UserQueries.FindOrCreateUser(Module.Context.User.Id).Result.Admin;
-            var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
-
-            foreach (var module in service.Modules)
-            {
-                var hideModule = false;
-                string description = null;
-
-                var moduleAttributes = module.Attributes.ToList();
-                if (moduleAttributes.Find(m => m.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute") != null)
-                {
-                    var preconditions = module.Preconditions.ToList();
-                    foreach (var pre in preconditions)
-                    {
-                        if (pre.TypeId.ToString() == "Cake.Core.Discord.Attributes.RequireBotAdminAttribute" || !isAdmin)
-                        {
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    hideModule = true;
-                }
-
-
-                if (hideModule)
-                {
-                    var commands = new List<CommandInfo>();
-                    foreach (var command in module.Commands)
-                    {
-                        var showCommand = true;
-                        var result = await command.CheckPreconditionsAsync(Module.Context);
-
-                        var commandAttributes = command.Attributes.ToList();
-                        if (commandAttributes.Find(m => m.Match(typeof(HideAttribute))) != null)
-                        {
-                            showCommand = false;
-                        }
-
-                        if (!result.IsSuccess || !showCommand) break;
-
-                        commands.Add(command);
-                    }
-
-                    if (commands.Count > 0)
-                    {
-                        var lastCommand = commands.Last();
-                        foreach (var command in commands)
-                        {
-                            if (lastCommand.Name == command.Name)
-                                description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__";
-                            else
-                                description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__ ``|`` ";
-                        }
-                    }
-                }
-
-
-                if (!string.IsNullOrWhiteSpace(description))
-                {
-                    builder.AddField(x =>
-                    {
-                        x.Name = $"{module.Name}";
-                        x.Value = description;
-                        x.IsInline = false;
-                    });
-                }
-            }
-
-            var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
-            await SendEmbedAsync(builder, dmChannel);
+        private bool ModuleHasHideAttribute(ModuleInfo module) {
+            return module.Attributes.Any(x => x.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute");
         }
 
-        public async Task HelpCommand(CommandService service, string command)
-        {
-            var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
-            var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
-            var result = service.Search(Module.Context, command);
-            if (!result.IsSuccess)
-            {
-                var builder1 = new CakeEmbedBuilder(EmbedType.Error)
-                {
-
-                    Title = "Error",
-                    Description = $"the command: **{command}** doesn't exist.\n{guild.Prefix}help for all commands."
-                };
-                await dmChannel.SendMessageAsync("", false, builder1.Build());
-                return;
-            }
-
-            var builder = new CakeEmbedBuilder(EmbedType.Info)
-            {
-                Description = $"Help about: **{command}**"
-            };
-
-            foreach (var match in result.Commands)
-            {
-                var cmd = match.Command;
-                string preconditions = null;
-                foreach (var precondition in cmd.Preconditions)
-                {
-                    preconditions += $"{precondition.TypeId}\n";
-                }
-
-                builder.AddField(x =>
-                {
-                    x.Name = "Command: " + string.Join(", ", cmd.Aliases);
-                    x.Value = $"**Usage:** {cmd.Summary}\n" +
-                              $"**Info:** {cmd.Remarks}\n" +
-                              $"**Preconditions:** {preconditions}";
-                    x.IsInline = false;
-                });
-            }
-
-            await dmChannel.SendMessageAsync("", false, builder.Build());
+        private bool CommandHasHideAttribute(CommandInfo command) {
+            return command.Attributes.Any(x => x.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute");
         }
+
+
+        //public async Task HelpAll(CommandService service)
+        //{
+        //    var builder = new CakeEmbedBuilder(EmbedType.Info)
+        //    {
+        //        Title = "My commands: "
+        //    };
+
+        //    var isAdmin = UserQueries.FindOrCreateUser(Module.Context.User.Id).Result.Admin;
+        //    var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
+
+        //    foreach (var module in service.Modules)
+        //    {
+        //        var hideModule = false;
+        //        string description = null;
+
+        //        var moduleAttributes = module.Attributes.ToList();
+        //        if (moduleAttributes.Find(m => m.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute") != null)
+        //        {
+        //            var preconditions = module.Preconditions.ToList();
+        //            foreach (var pre in preconditions)
+        //            {
+        //                if (pre.TypeId.ToString() == "Cake.Core.Discord.Attributes.RequireBotAdminAttribute" || !isAdmin)
+        //                {
+        //                    break;
+        //                }
+        //            }
+        //        }
+        //        else
+        //        {
+        //            hideModule = true;
+        //        }
+
+
+        //        if (hideModule)
+        //        {
+        //            var commands = new List<CommandInfo>();
+        //            foreach (var command in module.Commands)
+        //            {
+        //                var showCommand = true;
+        //                var result = await command.CheckPreconditionsAsync(Module.Context);
+
+        //                var commandAttributes = command.Attributes.ToList();
+        //                if (commandAttributes.Find(m => m.Match(typeof(HideAttribute))) != null)
+        //                {
+        //                    showCommand = false;
+        //                }
+
+        //                if (!result.IsSuccess || !showCommand) break;
+
+        //                commands.Add(command);
+        //            }
+
+        //            if (commands.Count > 0)
+        //            {
+        //                var lastCommand = commands.Last();
+        //                foreach (var command in commands)
+        //                {
+        //                    if (lastCommand.Name == command.Name)
+        //                        description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__";
+        //                    else
+        //                        description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__ ``|`` ";
+        //                }
+        //            }
+        //        }
+
+
+        //        if (!string.IsNullOrWhiteSpace(description))
+        //        {
+        //            builder.AddField(x =>
+        //            {
+        //                x.Name = $"{module.Name}";
+        //                x.Value = description;
+        //                x.IsInline = false;
+        //            });
+        //        }
+        //    }
+
+        //    var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
+        //    await SendEmbedAsync(builder, dmChannel);
+        //}
+
+        //public async Task HelpCommand(CommandService service, string command)
+        //{
+        //    var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
+        //    var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
+        //    var result = service.Search(Module.Context, command);
+        //    if (!result.IsSuccess)
+        //    {
+        //        var builder1 = new CakeEmbedBuilder(EmbedType.Error)
+        //        {
+
+        //            Title = "Error",
+        //            Description = $"the command: **{command}** doesn't exist.\n{guild.Prefix}help for all commands."
+        //        };
+        //        await dmChannel.SendMessageAsync("", false, builder1.Build());
+        //        return;
+        //    }
+
+        //    var builder = new CakeEmbedBuilder(EmbedType.Info)
+        //    {
+        //        Description = $"Help about: **{command}**"
+        //    };
+
+        //    foreach (var match in result.Commands)
+        //    {
+        //        var cmd = match.Command;
+        //        string preconditions = null;
+        //        foreach (var precondition in cmd.Preconditions)
+        //        {
+        //            preconditions += $"{precondition.TypeId}\n";
+        //        }
+
+        //        builder.AddField(x =>
+        //        {
+        //            x.Name = "Command: " + string.Join(", ", cmd.Aliases);
+        //            x.Value = $"**Usage:** {cmd.Summary}\n" +
+        //                      $"**Info:** {cmd.Remarks}\n" +
+        //                      $"**Preconditions:** {preconditions}";
+        //            x.IsInline = false;
+        //        });
+        //    }
+
+        //    await dmChannel.SendMessageAsync("", false, builder.Build());
+        //}
     }
 }

--- a/Cake.Core/Discord/Services/HelpService.cs
+++ b/Cake.Core/Discord/Services/HelpService.cs
@@ -32,10 +32,6 @@ namespace Cake.Core.Discord.Services
             }
 
             return Task.FromResult(helpPage);
-
-            #region Local_Function
-
-            #endregion
         }
 
         private void PopulateEmbedFieldsWithModuleCommands(ModuleInfo moduleInfo, ref CakeEmbedBuilder cakeEmbedBuilder, string commandSearchFilter = "")
@@ -106,7 +102,7 @@ namespace Cake.Core.Discord.Services
 
             string GetCommandDescriptionFromCommandInfo(CommandInfo commandInfo)
             {
-                return $"`{commandInfo.Summary}`; {commandInfo.Remarks}";
+                return $"`{commandInfo.Summary}`{ System.Environment.NewLine + commandInfo.Remarks}";
             }
 
             #endregion
@@ -116,7 +112,6 @@ namespace Cake.Core.Discord.Services
         {
             cakeEmbedBuilder.WithTitle(GetModuleName());
             cakeEmbedBuilder.WithDescription(GetModuleDescription());
-            // TODO: Fill footer with prefix of the bot.
 
             #region Local_Function
 

--- a/Cake.Core/Discord/Services/HelpService.cs
+++ b/Cake.Core/Discord/Services/HelpService.cs
@@ -12,29 +12,38 @@ namespace Cake.Core.Discord.Services
 {
     public class HelpService : CustomBaseService
     {
-        public Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service)
+        public Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service, string commandSearchFilter = "")
         {
             List<CakeEmbedBuilder> helpPage = new List<CakeEmbedBuilder>();
 
             foreach (ModuleInfo module in service.Modules)
             {
-                if (ModuleHasHideAttribute(module)) { continue; }
+                if (ModuleHasHideAttribute(module) || module.Commands.Count == 0) { continue; }
 
                 CakeEmbedBuilder newEmbedPage = new CakeEmbedBuilder();
 
                 PopulateEmbedWithModuleInfo(module, ref newEmbedPage);
-                PopulateEmbedFieldsWithModuleCommands(module, ref newEmbedPage);
+                PopulateEmbedFieldsWithModuleCommands(module, ref newEmbedPage, commandSearchFilter);
 
-                helpPage.Add(newEmbedPage);
+                if (newEmbedPage.Fields.Count > 0)
+                {
+                    helpPage.Add(newEmbedPage);
+                }
             }
 
             return Task.FromResult(helpPage);
+
+            #region Local_Function
+
+            #endregion
         }
 
-        private void PopulateEmbedFieldsWithModuleCommands(ModuleInfo moduleInfo, ref CakeEmbedBuilder cakeEmbedBuilder) {
+        private void PopulateEmbedFieldsWithModuleCommands(ModuleInfo moduleInfo, ref CakeEmbedBuilder cakeEmbedBuilder, string commandSearchFilter = "")
+        {
 
-            foreach (CommandInfo command in moduleInfo.Commands) {
-                if (CommandHasHideAttribute(command)) { continue; }
+            foreach (CommandInfo command in moduleInfo.Commands)
+            {
+                if (!CanAddCommandToEmbedField(command)) { continue; }
 
                 EmbedFieldBuilder commandField = GetEmbedFieldWithCommandInfo(command);
                 cakeEmbedBuilder.AddField(commandField);
@@ -42,7 +51,52 @@ namespace Cake.Core.Discord.Services
 
             #region Local_Function
 
-            EmbedFieldBuilder GetEmbedFieldWithCommandInfo(CommandInfo commandInfo) {
+            bool CanAddCommandToEmbedField(CommandInfo command)
+            {
+                if (CommandHasHideAttribute(command)) { return false; }
+
+                if (!string.IsNullOrWhiteSpace(commandSearchFilter))
+                {
+                    if (!CommandContainsSearchFilter(command))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            bool CommandContainsSearchFilter(CommandInfo command)
+            {
+                if (!string.IsNullOrWhiteSpace(command.Name))
+                {
+                    if (command.Name.Contains(commandSearchFilter))
+                    {
+                        return true;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(command.Remarks))
+                {
+                    if (command.Remarks.Contains(commandSearchFilter))
+                    {
+                        return true;
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(command.Summary))
+                {
+                    if (command.Summary.Contains(commandSearchFilter))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            EmbedFieldBuilder GetEmbedFieldWithCommandInfo(CommandInfo commandInfo)
+            {
                 EmbedFieldBuilder commandField = new EmbedFieldBuilder();
                 commandField.WithIsInline(true);
                 commandField.WithName(commandInfo.Name);
@@ -50,7 +104,8 @@ namespace Cake.Core.Discord.Services
                 return commandField;
             }
 
-            string GetCommandDescriptionFromCommandInfo(CommandInfo commandInfo) {
+            string GetCommandDescriptionFromCommandInfo(CommandInfo commandInfo)
+            {
                 return $"`{commandInfo.Summary}`; {commandInfo.Remarks}";
             }
 
@@ -65,7 +120,8 @@ namespace Cake.Core.Discord.Services
 
             #region Local_Function
 
-            string GetModuleDescription() {
+            string GetModuleDescription()
+            {
                 string moduleDescription = moduleInfo.Summary;
 
                 if (string.IsNullOrWhiteSpace(moduleDescription))
@@ -76,7 +132,8 @@ namespace Cake.Core.Discord.Services
                 return moduleDescription;
             }
 
-            string GetModuleName() {
+            string GetModuleName()
+            {
                 string moduleName = moduleInfo.Name;
                 // TODO: Possible refactor?
 
@@ -107,138 +164,14 @@ namespace Cake.Core.Discord.Services
             #endregion
         }
 
-        private bool ModuleHasHideAttribute(ModuleInfo module) {
+        private bool ModuleHasHideAttribute(ModuleInfo module)
+        {
             return module.Attributes.Any(x => x.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute");
         }
 
-        private bool CommandHasHideAttribute(CommandInfo command) {
+        private bool CommandHasHideAttribute(CommandInfo command)
+        {
             return command.Attributes.Any(x => x.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute");
         }
-
-
-        //public async Task HelpAll(CommandService service)
-        //{
-        //    var builder = new CakeEmbedBuilder(EmbedType.Info)
-        //    {
-        //        Title = "My commands: "
-        //    };
-
-        //    var isAdmin = UserQueries.FindOrCreateUser(Module.Context.User.Id).Result.Admin;
-        //    var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
-
-        //    foreach (var module in service.Modules)
-        //    {
-        //        var hideModule = false;
-        //        string description = null;
-
-        //        var moduleAttributes = module.Attributes.ToList();
-        //        if (moduleAttributes.Find(m => m.TypeId.ToString() == "Cake.Core.Discord.Attributes.HideAttribute") != null)
-        //        {
-        //            var preconditions = module.Preconditions.ToList();
-        //            foreach (var pre in preconditions)
-        //            {
-        //                if (pre.TypeId.ToString() == "Cake.Core.Discord.Attributes.RequireBotAdminAttribute" || !isAdmin)
-        //                {
-        //                    break;
-        //                }
-        //            }
-        //        }
-        //        else
-        //        {
-        //            hideModule = true;
-        //        }
-
-
-        //        if (hideModule)
-        //        {
-        //            var commands = new List<CommandInfo>();
-        //            foreach (var command in module.Commands)
-        //            {
-        //                var showCommand = true;
-        //                var result = await command.CheckPreconditionsAsync(Module.Context);
-
-        //                var commandAttributes = command.Attributes.ToList();
-        //                if (commandAttributes.Find(m => m.Match(typeof(HideAttribute))) != null)
-        //                {
-        //                    showCommand = false;
-        //                }
-
-        //                if (!result.IsSuccess || !showCommand) break;
-
-        //                commands.Add(command);
-        //            }
-
-        //            if (commands.Count > 0)
-        //            {
-        //                var lastCommand = commands.Last();
-        //                foreach (var command in commands)
-        //                {
-        //                    if (lastCommand.Name == command.Name)
-        //                        description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__";
-        //                    else
-        //                        description += $"__{guild.Prefix}{command.Module.Group} {command.Name}__ ``|`` ";
-        //                }
-        //            }
-        //        }
-
-
-        //        if (!string.IsNullOrWhiteSpace(description))
-        //        {
-        //            builder.AddField(x =>
-        //            {
-        //                x.Name = $"{module.Name}";
-        //                x.Value = description;
-        //                x.IsInline = false;
-        //            });
-        //        }
-        //    }
-
-        //    var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
-        //    await SendEmbedAsync(builder, dmChannel);
-        //}
-
-        //public async Task HelpCommand(CommandService service, string command)
-        //{
-        //    var guild = await GuildQueries.FindOrCreateGuild(Module.Context.Guild.Id).ConfigureAwait(false);
-        //    var dmChannel = await Module.Context.User.GetOrCreateDMChannelAsync();
-        //    var result = service.Search(Module.Context, command);
-        //    if (!result.IsSuccess)
-        //    {
-        //        var builder1 = new CakeEmbedBuilder(EmbedType.Error)
-        //        {
-
-        //            Title = "Error",
-        //            Description = $"the command: **{command}** doesn't exist.\n{guild.Prefix}help for all commands."
-        //        };
-        //        await dmChannel.SendMessageAsync("", false, builder1.Build());
-        //        return;
-        //    }
-
-        //    var builder = new CakeEmbedBuilder(EmbedType.Info)
-        //    {
-        //        Description = $"Help about: **{command}**"
-        //    };
-
-        //    foreach (var match in result.Commands)
-        //    {
-        //        var cmd = match.Command;
-        //        string preconditions = null;
-        //        foreach (var precondition in cmd.Preconditions)
-        //        {
-        //            preconditions += $"{precondition.TypeId}\n";
-        //        }
-
-        //        builder.AddField(x =>
-        //        {
-        //            x.Name = "Command: " + string.Join(", ", cmd.Aliases);
-        //            x.Value = $"**Usage:** {cmd.Summary}\n" +
-        //                      $"**Info:** {cmd.Remarks}\n" +
-        //                      $"**Preconditions:** {preconditions}";
-        //            x.IsInline = false;
-        //        });
-        //    }
-
-        //    await dmChannel.SendMessageAsync("", false, builder.Build());
-        //}
     }
 }

--- a/Cake.Core/Discord/Services/HelpService.cs
+++ b/Cake.Core/Discord/Services/HelpService.cs
@@ -1,10 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Cake.Core.Discord.Attributes;
 using Cake.Core.Discord.Embed.Builder;
-using Cake.Database.Queries;
 using Discord;
 using Discord.Commands;
 
@@ -15,6 +12,8 @@ namespace Cake.Core.Discord.Services
         public Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service, string commandSearchFilter = "")
         {
             List<CakeEmbedBuilder> helpPage = new List<CakeEmbedBuilder>();
+
+            int pageNumber = 1;
 
             foreach (ModuleInfo module in service.Modules)
             {
@@ -27,7 +26,9 @@ namespace Cake.Core.Discord.Services
 
                 if (newEmbedPage.Fields.Count > 0)
                 {
+                    newEmbedPage.WithFooter(pageNumber.ToString());
                     helpPage.Add(newEmbedPage);
+                    ++pageNumber;
                 }
             }
 
@@ -102,7 +103,7 @@ namespace Cake.Core.Discord.Services
 
             string GetCommandDescriptionFromCommandInfo(CommandInfo commandInfo)
             {
-                return $"`{commandInfo.Summary}`{ System.Environment.NewLine + commandInfo.Remarks}";
+                return $"`{commandInfo.Summary}` { System.Environment.NewLine + commandInfo.Remarks}";
             }
 
             #endregion

--- a/Cake.Core/Discord/Services/HelpService.cs
+++ b/Cake.Core/Discord/Services/HelpService.cs
@@ -11,7 +11,7 @@ namespace Cake.Core.Discord.Services
     {
         public Task<List<CakeEmbedBuilder>> FetchAllCommandInfoAsPages(CommandService service, string commandSearchFilter = "")
         {
-            List<CakeEmbedBuilder> helpPage = new List<CakeEmbedBuilder>();
+            List<CakeEmbedBuilder> helpBook = new List<CakeEmbedBuilder>();
 
             int pageNumber = 1;
 
@@ -27,12 +27,13 @@ namespace Cake.Core.Discord.Services
                 if (newEmbedPage.Fields.Count > 0)
                 {
                     newEmbedPage.WithFooter(pageNumber.ToString());
-                    helpPage.Add(newEmbedPage);
                     ++pageNumber;
+
+                    helpBook.Add(newEmbedPage);
                 }
             }
 
-            return Task.FromResult(helpPage);
+            return Task.FromResult(helpBook);
         }
 
         private void PopulateEmbedFieldsWithModuleCommands(ModuleInfo moduleInfo, ref CakeEmbedBuilder cakeEmbedBuilder, string commandSearchFilter = "")
@@ -103,7 +104,7 @@ namespace Cake.Core.Discord.Services
 
             string GetCommandDescriptionFromCommandInfo(CommandInfo commandInfo)
             {
-                return $"`{commandInfo.Summary}` { System.Environment.NewLine + commandInfo.Remarks}";
+                return $"`{commandInfo.Summary}`{ System.Environment.NewLine + commandInfo.Remarks}";
             }
 
             #endregion


### PR DESCRIPTION
Based on #3 

`help` just simply lists out all the commands in an embed.<br>The user can navigate through the different pages using the LeftArrow and RightArrow emoji.

*Alternatively*, the user can also filter the search by `help (filterHere)`.<br>In-code, it just uses `string.Contains` on the `Summary`, `Remarks` and `Name` attribute if applicable.

Pages are separated based on modules rather than length.

>The bot will just say a warning if the filter failed to find any respective commands.
The bot will not show the respective emojis if the commands can fit into a page.

### Code Design
**For handling Message Reactions**

`CommandHandler` makes the respective static `MessageReactionHandler` function subscribe to the respective `Client` object reaction event-handlers.

To make an object have a callback when a reaction-related event occurs to a message, let it implement `IMessageReactionHandle` and call `AddMessageReactionHandle` from `MessageReactionHandler`, with the input being the respective object.

Just remember to call `RemoveMessageReactionHandle` after you are done, with the input being the respective object.